### PR TITLE
спринт между 17 и 18

### DIFF
--- a/app/src/main/java/com/practicum/playlistmaker/player/data/dto/TrackDto.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/data/dto/TrackDto.kt
@@ -14,5 +14,5 @@ data class TrackDto(
     val releaseDate: String,
     val primaryGenreName: String,
     val country: String,
-    val previewUrl: String
+    val previewUrl: String?
 ) : Parcelable

--- a/app/src/main/java/com/practicum/playlistmaker/player/data/impl/PlayerRepositoryImpl.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/data/impl/PlayerRepositoryImpl.kt
@@ -14,7 +14,7 @@ class PlayerRepositoryImpl(
     private val currentTrack = trackInteractor.loadTrack()
 
     override fun preparePlayer(
-        trackUrl: String,
+        trackUrl: String?,
         onComplete: () -> Unit
     ) {
         mediaPlayer.setDataSource(trackUrl)

--- a/app/src/main/java/com/practicum/playlistmaker/player/domain/PlayerInteractor.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/domain/PlayerInteractor.kt
@@ -3,7 +3,7 @@ package com.practicum.playlistmaker.player.domain
 import com.practicum.playlistmaker.player.domain.model.Track
 
 interface PlayerInteractor {
-    fun preparePlayer(trackUrl: String, onComplete: () -> Unit)
+    fun preparePlayer(trackUrl: String?, onComplete: () -> Unit)
 
     fun startPlayer(statusObserver: StatusObserver)
     fun pausePlayer()

--- a/app/src/main/java/com/practicum/playlistmaker/player/domain/api/PlayerRepository.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/domain/api/PlayerRepository.kt
@@ -4,7 +4,7 @@ import com.practicum.playlistmaker.player.domain.model.Track
 
 interface PlayerRepository {
 
-    fun preparePlayer(trackUrl: String, onComplete: () -> Unit)
+    fun preparePlayer(trackUrl: String?, onComplete: () -> Unit)
     fun startPlayer()
     fun pausePlayer()
     fun resetPlayer()

--- a/app/src/main/java/com/practicum/playlistmaker/player/domain/impl/PlayerInteractorImpl.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/domain/impl/PlayerInteractorImpl.kt
@@ -9,7 +9,7 @@ class PlayerInteractorImpl(private val repository: PlayerRepository) : PlayerInt
     private var statusObserver: PlayerInteractor.StatusObserver? = null
 
     override fun preparePlayer(
-        trackUrl: String,
+        trackUrl: String?,
         onComplete: () -> Unit
     ) {
         repository.preparePlayer(

--- a/app/src/main/java/com/practicum/playlistmaker/player/domain/model/Track.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/domain/model/Track.kt
@@ -10,5 +10,5 @@ data class Track(
     val releaseDate: String,
     val primaryGenreName: String,
     val country: String,
-    val previewUrl: String
+    val previewUrl: String?
 )

--- a/app/src/main/java/com/practicum/playlistmaker/player/ui/activity/PlayerActivity.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/ui/activity/PlayerActivity.kt
@@ -1,6 +1,7 @@
 package com.practicum.playlistmaker.player.ui.activity
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
@@ -42,13 +43,27 @@ class PlayerActivity : AppCompatActivity() {
         setListeners()
     }
 
+    override fun onPause() {
+        super.onPause()
+        viewModel.pause()
+    }
+
     private fun setListeners() {
         binding.backFromAudioPlayer.setOnClickListener {
             finish()
         }
         binding.playButton.setOnClickListener {
-            setPlayButtonAction(viewModel.getPlayStatusLiveData().value)
+            if (viewModel.isPreviewUrlValid()) {
+                setPlayButtonAction(viewModel.getPlayStatusLiveData().value)
+            } else {
+                showEmptySongToast()
+            }
         }
+    }
+
+    private fun showEmptySongToast() {
+        val message = getString(R.string.song_is_not_available)
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
     private fun setPlayButtonAction(playStatus: PlayStatus?) {

--- a/app/src/main/java/com/practicum/playlistmaker/player/ui/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/player/ui/viewmodel/PlayerViewModel.kt
@@ -14,6 +14,8 @@ class PlayerViewModel(
     private val playerInteractor: PlayerInteractor,
 ) : ViewModel() {
 
+    private val previewUrl = playerInteractor.getTrack().previewUrl
+
     private val playStatusLiveData = MutableLiveData<PlayStatus>()
     private val progressLiveData = MutableLiveData<Int>()
 
@@ -27,14 +29,20 @@ class PlayerViewModel(
     }
 
     init {
-        playerInteractor.preparePlayer(
-            trackUrl = playerInteractor.getTrack().previewUrl,
-            onComplete = {
-                mainThreadHandler.removeCallbacks(progressUpdateRunnable)
-                playStatusLiveData.postValue(getCurrentPlayStatus().copy(isPlaying = false))
-                progressLiveData.postValue(0)
-            }
-        )
+
+        if (previewUrl != null) {
+
+            playerInteractor.preparePlayer(
+                trackUrl = previewUrl,
+                onComplete = {
+                    mainThreadHandler.removeCallbacks(progressUpdateRunnable)
+                    playStatusLiveData.postValue(getCurrentPlayStatus().copy(isPlaying = false))
+                    progressLiveData.postValue(0)
+                }
+            )
+
+        }
+
     }
 
     fun getPlayStatusLiveData(): LiveData<PlayStatus> = playStatusLiveData
@@ -63,6 +71,10 @@ class PlayerViewModel(
 
     fun provideCurrentTrack(): Track {
         return playerInteractor.getTrack()
+    }
+
+    fun isPreviewUrlValid(): Boolean {
+        return (previewUrl != null)
     }
 
     private fun getCurrentPlayStatus(): PlayStatus {

--- a/app/src/main/res/layout/track_view.xml
+++ b/app/src/main/res/layout/track_view.xml
@@ -6,6 +6,14 @@
     android:layout_height="wrap_content"
     android:background="@color/customBackground">
 
+    <androidx.constraintlayout.widget.Guideline
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/the_guideline"
+        app:layout_constraintEnd_toStartOf="@id/arrow_forward"
+        android:orientation="vertical"
+        />
+
     <ImageView
         android:id="@+id/cover"
         android:layout_width="@dimen/cover_size45"
@@ -20,7 +28,7 @@
 
     <TextView
         android:id="@+id/track_name"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/offset8"
         android:layout_marginTop="@dimen/offset14"
@@ -48,10 +56,10 @@
         android:lines="1"
         android:textColor="@color/customIconTint"
         android:textSize="@dimen/text11"
-        app:layout_constraintBottom_toBottomOf="@id/the_dot"
+        app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toStartOf="@id/the_dot"
         app:layout_constraintStart_toEndOf="@id/cover"
-        app:layout_constraintTop_toTopOf="@id/the_dot"
+        app:layout_constraintTop_toBottomOf="@id/track_name"
         tools:text="The Beatles" />
 
     <ImageView
@@ -61,10 +69,9 @@
         android:layout_gravity="center"
         android:layout_marginTop="@dimen/offset1"
         android:scaleType="center"
-        android:src="@drawable/ic_ellipse_1"
-        app:layout_constraintEnd_toStartOf="@id/track_time"
+        app:layout_constraintTop_toBottomOf="@id/track_name"
         app:layout_constraintStart_toEndOf="@id/artist_name"
-        app:layout_constraintTop_toBottomOf="@id/track_name" />
+        android:src="@drawable/ic_ellipse_1" />
 
     <TextView
         android:id="@+id/track_time"
@@ -74,10 +81,10 @@
         android:fontFamily="@font/ys_display_regular"
         android:textColor="@color/customIconTint"
         android:textSize="@dimen/text11"
-        app:layout_constraintBottom_toBottomOf="@id/the_dot"
-        app:layout_constraintStart_toEndOf="@+id/the_dot"
-        app:layout_constraintTop_toTopOf="@id/the_dot"
-
+        app:layout_constraintTop_toBottomOf="@id/track_name"
+        app:layout_constraintStart_toEndOf="@id/the_dot"
+        app:layout_constraintEnd_toStartOf="@id/the_guideline"
+        app:layout_constraintHorizontal_bias="0.0"
         tools:text="2:55" />
 
     <ImageView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,5 @@
     <string name="empty_string"></string>
     <string name="search_error_minus1">Проблемы со связью\nЗагрузка не удалась. Проверьте\nподключение к интернету</string>
     <string name="search_error_else">Ошибка сервера</string>
+    <string name="song_is_not_available">Песня недоступна для воспроизведения</string>
 </resources>


### PR DESCRIPTION
 - исправление некритического замечания с последнего ревью: Дефект прошлых спринтов: треки с ОЧЕНЬ длинным названием альбома показываются неправильно. Строка не обрезается, длительность трека НЕ показывается. Проверь поиском слова "Метелица" - там таких примеров будет три.
 - если previewUrl нет, апп не вылетает и при нажатии на плей выходит соответсвтующий тост.
  - теперь при сворачинвании или блокировки плеер останавливается.